### PR TITLE
List node version requirements in Github installation instructions

### DIFF
--- a/documentation/installation-from-github.html
+++ b/documentation/installation-from-github.html
@@ -86,7 +86,11 @@
 
          <p class="support"><b>Support Respond!</b> You can support the development of Respond 6 by using our <a href="https://www.digitalocean.com/?refcode=a0ca7859692b">Digital Ocean referral Code</a>. This helps us pay for hosting.</p>
 
-         <p>Are you ready to get started developing with Respond? Learn how to install Respond on a traditional LAMP deployment and setup UI development using the Angular CLI.&nbsp;</p><p><b>Quick Note: </b>This installation process is built to enable fast development for Respond, and as such, assumes you have basic understanding of Laravel, PHP, and the Angular CLI. &nbsp;If these are new concepts, spend some time reading up on them before moving forward.</p>
+         <p>Are you ready to get started developing with Respond? Learn how to install Respond on a traditional LAMP deployment and setup UI development using the Angular CLI.&nbsp;</p>
+        
+         <p>This installation process is built to enable fast development for Respond, and as such, assumes you have basic understanding of Laravel, PHP, and the Angular CLI. &nbsp;If these are new concepts, spend some time reading up on them before moving forward.</p>
+        
+         <p>In addition to the <a href="server-requirements">base server requirements</a>, your system will need to have the latest versions of nodejs (9.x+) and npm (5.6+) installed. You can determine which versions are currently installed on your system using the commands <code>nodejs -v</code> and <code>npm -v</code>.</p>
 
          <h3>1. Create the directory structure for Respond</h3>
          <p>You create your directory structure by navigating to your web root and creating folders for Respond. You can also do this using a graphical tool (such as sFTP). Below we are creating the following structure: <code>var/www/html/respond/app</code>.  We are also adding a <code>var/www/html/respond/app/public/sites</code> folder that will hold the sites and a <code>var/www/html/respond/app/resources/sites</code> folder that will hold private data about your sites.</p>


### PR DESCRIPTION
As someone who is relatively new to the node / npm world, I've spent countless hours struggling to get various versions of Respond 6 installed correctly. Attempting to install Respond with earlier versions of node / npm results in pages of cryptic, unhelpful error messages. It took me a while, but I eventually learned that almost all of the errors relate to not having the same versions of node / npm installed that you used to develop Respond. Ubuntu Linux in particular ships with very old versions. By listing the version requirements on the developer install page I hope to save others the same frustration and enable them to more quickly get the CMS installed.

I am pretty sure these version requirements are correct. I tried installing Respond using nodejs 8 and couldn't get it to work. Once I upgraded to nodejs 9 it worked fine.